### PR TITLE
USB serial device filter for Linux

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -73,6 +73,10 @@ Application::Application(){
 
     rightLayout->addWidget(new QLabel("COM port:"));
     rightLayout->addWidget(comPortList = new QListWidget());
+#ifdef Q_OS_LINUX
+    rightLayout->addWidget(comShowAllCheckbox = new QCheckBox("Show all ports"));
+    QObject::connect (comShowAllCheckbox, SIGNAL(stateChanged(int)), this, SLOT(refreshPorts(int)));
+#endif
     rightLayout->addWidget(refreshButton = new QPushButton("Refresh"));
     rightLayout->addWidget(connectButton = new QPushButton("Connect"));
     rightLayout->addWidget(disconnectButton = new QPushButton("Disconnect"));
@@ -259,6 +263,12 @@ void Application::refreshPorts(){
     QList<QSerialPortInfo> ports = QSerialPortInfo::availablePorts();
     comPortList->clear();
     for(int i = 0;i < ports.size();++i){
+#ifdef Q_OS_LINUX
+        /* Filter ports starting with ttyS, since those are system ports */
+        if(!comShowAllCheckbox->isChecked() && ports[i].portName().contains("ttyS")){
+           continue;
+        }
+#endif
         comPortList->addItem(ports[i].portName());
     }
 }

--- a/src/Application.h
+++ b/src/Application.h
@@ -69,6 +69,9 @@ private:
     QWidget *rightPanel;
 
     QListWidget* comPortList;
+#ifdef Q_OS_LINUX
+    QCheckBox* comShowAllCheckbox;
+#endif
     QPushButton* connectButton;
     QPushButton* disconnectButton;
     QPushButton* refreshButton;
@@ -94,6 +97,12 @@ protected:
 private slots:
     void quit();
     void refreshPorts();
+#ifdef Q_OS_LINUX
+    void refreshPorts(int filter) {
+      /* Used by comShowAllCheckbox */
+      refreshPorts();
+    }
+#endif
     void connectPort();
     void disconnectPort();
     void readPort();


### PR DESCRIPTION
By default all serial ports in format `/dev/ttyS*` are filtered out. The USB either appears as ttyACM or ttyUSB.
Checkbox is added to show full list in case this would be needed.